### PR TITLE
Fix safari client error when joining collab session

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,8 +67,6 @@ app.use(async (ctx) => {
     db.listen(ws, docId);
   } else {
     ctx.body = 'Document exists.';
-    ctx.set('Upgrade', 'WebSocket');
-    ctx.set('Connection', 'Upgrade');
   }
 });
 


### PR DESCRIPTION
Fixes https://github.com/source-academy/frontend/issues/2235

## Description

- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection

The bug occurs because safari does not load any responses that contains the `Connection` header when `http2` is selected as the protocol.

![safari-error](https://user-images.githubusercontent.com/47914880/194765686-4f3f51fa-58ad-4193-aab2-7b1de27bda3c.png)

## Fix

Since the frontend only checks for a valid response (see below) when a client tries to join a collaborative session, there is no need for the additional `Connection` and `Upgrade` headers.

https://github.com/source-academy/frontend/blob/ba61a6990415e3b15be56cbaa437fad329b92ce3/src/commons/collabEditing/CollabEditingHelper.ts#L16-L20

After all, the websocket connection will still be established by `sharedbAce` (below) after the initial `POST` sent when joining a session

https://github.com/source-academy/frontend/blob/ba61a6990415e3b15be56cbaa437fad329b92ce3/src/commons/editor/UseShareAce.tsx#L29-L33

## Testing

Tested using a local `nginx` with prod configs, with a local `https` (self-signed) frontend.

```conf
server {
  listen 80 default_server;
  listen [::]:80 default_server;
  server_name  localhost;

  listen 443 ssl http2 default_server;
  listen [::]:443 ssl http2 default_server;

  ssl_certificate /tmp/sharedb.crt; # self signed
  ssl_certificate_key /tmp/sharedb.key;

  location /sharedb/ {
     proxy_pass http://127.0.0.1:8080/; # sharedb-ace-backend endpoint
     proxy_http_version 1.1;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection "Upgrade";
     proxy_set_header Host $host;
     proxy_cache_bypass $http_upgrade;
  }
}
```

### Response after fix

<img width="1322" alt="image" src="https://user-images.githubusercontent.com/47914880/194766495-ce8355c9-8eec-452a-b00d-cfee8839bd8b.png">

<img width="962" alt="image" src="https://user-images.githubusercontent.com/47914880/194766547-438c99cd-74cd-4be5-a195-6b58fad0a31d.png">

Verified that it was a `http2` request.
